### PR TITLE
🔒 Fix Command Injection in PR Check

### DIFF
--- a/.github/workflows/3-open-a-pull-request.yml
+++ b/.github/workflows/3-open-a-pull-request.yml
@@ -60,6 +60,9 @@ jobs:
 
       - name: Check user work
         id: check-user-work
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           # Checks to perform
           checks='{
@@ -76,13 +79,13 @@ jobs:
           }'
 
           # Check pull request title
-          if [ "${{ github.event.pull_request.title }}" != "Add my first file" ]; then
+          if [ "$PR_TITLE" != "Add my first file" ]; then
             checks=$(echo $checks | jq '.pr_title.passed = false')
             checks=$(echo $checks | jq '.pr_title.message = "Incorrect title"')
           fi
 
           # Check if a pull request description exists
-          if [ "${{ github.event.pull_request.body }}" == "" ]; then
+          if [ "$PR_BODY" == "" ]; then
             checks=$(echo $checks | jq '.pr_description.passed = false')
             checks=$(echo $checks | jq '.pr_description.message = "Empty pull request description"')
           fi


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
In the `.github/workflows/3-open-a-pull-request.yml` file, the pull request title and body were being directly interpolated into a bash script execution step. 

⚠️ **Risk:** The potential impact if left unfixed
Directly evaluating GitHub expressions containing user-controlled input in a bash script introduces a command injection vulnerability. An attacker could craft a malicious pull request title or body containing shell execution characters, executing arbitrary commands within the workflow environment and compromising the repository.

🛡️ **Solution:** How the fix addresses the vulnerability
This change moves the potentially malicious `github.event.pull_request.title` and `github.event.pull_request.body` expression evaluations into an `env` block. The bash script has been updated to use the resulting securely mapped environment variables `$PR_TITLE` and `$PR_BODY` instead, which prevents the user input from executing arbitrary shell commands.

---
*PR created automatically by Jules for task [15849401468242332918](https://jules.google.com/task/15849401468242332918) started by @blaze229*